### PR TITLE
Setting the dynamic_preference dependency to an older migration, beca…

### DIFF
--- a/ldap_probe/migrations/0047_0001_to_0045_data.py
+++ b/ldap_probe/migrations/0047_0001_to_0045_data.py
@@ -258,7 +258,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('ldap_probe', '0046_0001_to_0043_model'),
-        ('dynamic_preferences', '0006_auto_20191120_1041'),
+        ('dynamic_preferences', '0004_move_user_model'),
     ]
 
     operations = [


### PR DESCRIPTION
…use the migrations applied on the prod/qa machines don't match the ones in development (and we don't need the latest migration).

https://phsasocapp.atlassian.net/browse/SA-33