### PR TITLE
Add the old name to the 'replaces' lists of migrations that were rena…

### DIFF
--- a/citrus_borg/migrations/0009_prepare_task_schedules.py
+++ b/citrus_borg/migrations/0009_prepare_task_schedules.py
@@ -47,6 +47,10 @@ def prepare_task_schedules(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    replaces = [
+        ('citrus_borg', '0009_prepare_task_scheddules'),
+    ]
+
 
     dependencies = [
         ('citrus_borg', '0007_populate_bots'),

--- a/ldap_probe/migrations/0015_really_add_beats_for_ldap_data.py
+++ b/ldap_probe/migrations/0015_really_add_beats_for_ldap_data.py
@@ -49,6 +49,9 @@ def add_beats(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    replaces = [
+        ('ldap_probe', '0015_realy_add_beats_for_ldap_data'),
+    ]
 
     dependencies = [
         ('ldap_probe', '0010_add_beats_for_ldap_data'),


### PR DESCRIPTION
When renaming migrations one needs to make sure the newly named migration replaces the old one.